### PR TITLE
Add init subcommand and allow re-initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
 
+# test
+test/
+
 # Intellij
 .idea/

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,0 +1,59 @@
+//! The `init` subcommand
+//! This command initializes a new Cazan project
+//! It creates a new directory named `.cazan` in the current working directory with some default files
+//!
+//! Optionally, if the `--re-init` flag is used, it will re-initialize an existing Cazan project.
+//! This will overwrite the existing `.cazan` directory and all of its contents.
+
+use super::SubCommandTrait;
+use argh::FromArgs;
+use std::fs;
+
+#[derive(PartialEq, Debug, FromArgs)]
+#[argh(
+    subcommand,
+    name = "init",
+    description = "initialize a new Cazan project"
+)]
+pub struct Init {
+    #[argh(
+        switch,
+        short = 'r',
+        description = "re-initialize an existing Cazan project"
+    )]
+    pub re_init: bool,
+}
+
+impl SubCommandTrait for Init {
+    fn run(&self) {
+        if self.re_init {
+            println!("Re-initializing Cazan project");
+        } else {
+            println!("Initializing Cazan project");
+        }
+
+        match fs::create_dir(".cazan") {
+            Ok(_) => {}
+            Err(_) => {
+                if self.re_init {
+                    fs::remove_dir_all(".cazan").expect("Failed to remove .cazan directory");
+                    fs::create_dir(".cazan").expect("Failed to create .cazan directory");
+                } else {
+                    println!("A Cazan project already exists in this directory");
+                    return;
+                }
+            }
+        }
+        fs::write(
+            ".cazan/cazan.json",
+            r#"{
+  "assets-dir": {
+      "input": "assets",
+      "output": ".cazan/assets"
+  }
+}"#,
+        )
+        .expect("Failed to create .cazan/cazan.json file");
+        fs::create_dir(".cazan/assets").expect("Failed to create .cazan/assets directory");
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,8 @@
+mod init;
 mod subcommands;
 
 use argh::FromArgs;
-pub use subcommands::Subcommand;
+pub use subcommands::{SubCommandEnum, SubCommandTrait};
 
 #[derive(FromArgs, Debug)]
 #[argh(
@@ -9,9 +10,9 @@ pub use subcommands::Subcommand;
     description = "The Command Line Tool to install to build your Cazan project"
 )]
 pub(crate) struct Cli {
-    #[argh(option, short = 'v', description = "print version info")]
+    #[argh(switch, short = 'v', description = "print version info")]
     pub(crate) version: bool,
 
     #[argh(subcommand)]
-    pub subcommand: Option<Subcommand>,
+    pub subcommand: Option<SubCommandEnum>,
 }

--- a/src/cli/subcommands.rs
+++ b/src/cli/subcommands.rs
@@ -1,5 +1,22 @@
+use super::init::Init;
 use argh::FromArgs;
 
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand)]
-pub enum Subcommand {}
+pub enum SubCommandEnum {
+    Init(Init),
+}
+
+pub trait SubCommandTrait {
+    fn run(&self);
+}
+
+impl SubCommandEnum {
+    pub fn run(&self) {
+        match self {
+            SubCommandEnum::Init(init) => {
+                init.run();
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,16 @@ fn main() {
     let cli: cli::Cli = argh::from_env();
 
     if cli.version {
-        println!("cazan version {}", env!("CARGO_PKG_VERSION"));
+        println!("cazan-cli version {}", env!("CARGO_PKG_VERSION"));
         return;
     }
 
     match cli.subcommand {
-        None => {}
-        Some(_) => {}
+        Some(subcommand) => {
+            subcommand.run();
+        }
+        None => {
+            println!("Error: No subcommand was used");
+        }
     }
 }


### PR DESCRIPTION
This commit adds a new `init` subcommand to the CLI for creating a new Cazan project. This includes the creation of a new directory named `.cazan` in the current working directory, along with some default files. Furthermore, a `--re-init` flag has also been introduced which will allow for the re-initialization of an existing Cazan project. This means an existing `.cazan` directory and all of its contents can now be overwritten.